### PR TITLE
Fix bug in suggestion notification email to admins

### DIFF
--- a/app/mailers/suggestion_mailer.rb
+++ b/app/mailers/suggestion_mailer.rb
@@ -11,6 +11,7 @@ class SuggestionMailer < ApplicationMailer
     @person = person
     @suggester = suggester
     @suggestion = Suggestion.new(suggestion_hash)
+    @admin = admin
     mail to: admin.email
   end
 end

--- a/app/views/suggestion_mailer/team_admin_email.html.erb
+++ b/app/views/suggestion_mailer/team_admin_email.html.erb
@@ -10,7 +10,7 @@
         </tr>
         <tr>
           <td width="560" align="left" valign="top" style="font-family:Arial, sans-serif;font-size:16px;font-weight:normal;line-height:30px;color:#434343;border-collapse:collapse;">
-            Hello <%= @person.given_name %>,
+            Hello <%= @admin.given_name %>,
           </td>
         </tr>
         <tr>

--- a/spec/mailers/suggestion_mailer_spec.rb
+++ b/spec/mailers/suggestion_mailer_spec.rb
@@ -84,6 +84,10 @@ RSpec.describe SuggestionMailer do
       expect(mail.to).to include(admin.email)
     end
 
+    it 'contains the name of the admin' do
+      expect_mail_body_text(admin.given_name)
+    end
+
     it 'contains the name of the suggester' do
       expect_mail_body_text(suggester.name)
     end


### PR DESCRIPTION
👋 from GDS.

Leaders in a team receive an email when people make suggestions about someones profile. However the emails start with "Hello {name of the profile owner}". Presumably this is caused by the fact that in other emails the `@person` ivar refers to the recipient.

You can see the bug in action here:

<img width="623" alt="screen shot 2016-11-30 at 12 54 49" src="https://cloud.githubusercontent.com/assets/233676/20753397/25ced002-b6fe-11e6-9a18-4fce2457f992.png">

